### PR TITLE
Issue #3: Add missing module key to feeds plugin definition

### DIFF
--- a/feeds_jsonpath_parser.module
+++ b/feeds_jsonpath_parser.module
@@ -31,6 +31,7 @@ function feeds_jsonpath_parser_autoload_info() {
 function feeds_jsonpath_parser_feeds_plugins() {
   return array(
     'FeedsJSONPathParser' => array(
+      'module' => 'feeds_jsonpath_parser',
       'name' => t('JSONPath parser'),
       'description' => t('Parse JSON files using JSONPath.'),
       'handler' => array(


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/feeds_jsonpath_parser/issues/3